### PR TITLE
📜 Contextualize greater looming threat

### DIFF
--- a/TAR-S7-27-15.md
+++ b/TAR-S7-27-15.md
@@ -316,6 +316,16 @@ https://www.sec.gov/Archives/edgar/data/886158/000088615823000059/bbby-20230225.
 
 ### Specific UCC Changes from Don Grande
 
+
+> Allowing massive institutions, many of which are worth hundreds of billions of dollars, to have priority over security entitlements belonging to individual investors creates massive distortions in the marketplace that could ultimately hasten a large economic crash. But even if this were not the case, an important question for policymakers remains: Is a system truly worthy of saving if it would happily sacrifice individual investors’ wealth to save allegedly too-big-to-fail institutions?
+> 
+> —The Heartland Institute
+
+https://heartland.org/wp-content/uploads/2024/01/1-26-24-UCC-Article-8-State-Legislative-Alert_Final.pdf
+
+
+
+
 Firsly we can cite these MF's absolite nothingball of deception:
 : _See_ https://wooten.link/ULC-fraud
 

--- a/TAR-S7-27-15.md
+++ b/TAR-S7-27-15.md
@@ -8,7 +8,7 @@ Discussion: https://github.com/WhyDRS/SEC-Comments/discussions/14
 Status: Draft
   live: 28 Jan 2025
   file: S7-27-15
-  href: SEC_URL # for when submitted
+  href: https://www.sec.gov/files/rules/concept/2015/34-76743.pdf
 ```
 
 #### Header
@@ -151,7 +151,7 @@ Our market's tabulators should not need multiple differnet methods to remedy the
 
 As the COmmission knows, Article 8 of the UCC created these entitlements in 1994, legally seperating investors from what was previously their propery so that brokers could employ them for their own collateral. However, as we'll fund menaingul later, the DTC's lawyers already had States make the requisite custodianshpi opraetional efficincy thchange in 1972.[^BASIC-UCC] Upon an electronic-record modernization update in 1978, the UCC contained all required interemdiary righta and protections tp offer margin accounts and associated hypothecation products.[^FSU-UCC]
 
-[^BASIC-UCC]: _See_ remakrs on the BANKING AND SECURITIES INDUSTRY COMMITTEE amendaments to UCC in 1972 to enable the cusotdiahsp and immobalization neccesary for margin loans, _available at_ https://www.sechistorical.org/collection/papers/1980/1984_0401_BasicTeamwork_1.pdf#page=69. Upon the adoption of these new State laws, "DTC commenced taking steps to implement the long-desired broadening of its ownership, even though a small percentage of its eligible issues would be from non-enacting states." As the Commision knows, this ownership stake often exceeds 99.9% of public issuers, presenting an immmense centraliztion risk should its nonimnee partnership face any threats.
+[^BASIC-UCC]: _See_ remakrs on the BANKING AND SECURITIES INDUSTRY COMMITTEE amendaments to UCC in 1972, mentioned in the concept release at n.62, enabling the cusotdiahsp and immobalization neccesary for margin loans, _available at_ https://www.sechistorical.org/collection/papers/1980/1984_0401_BasicTeamwork_1.pdf#page=69. Upon the adoption of these new State laws, "DTC commenced taking steps to implement the long-desired broadening of its ownership, even though a small percentage of its eligible issues would be from non-enacting states." As the Commision knows, this ownership stake often exceeds 99.9% of public issuers, presenting an immmense centraliztion risk should its nonimnee partnership face any threats.
 
 [^FSU-UCC]: _See_ Florida State Universit Law Review's article: _A Critical Look at Secured Transactions Under Revised UCC Article 8_, _available at_ https://ir.law.fsu.edu/lr/vol14/iss4/2. In 1987, Dr. Paul B. Rasor, Ph.D. therein states that:
 > The extension of article 8 to uncertified shareholder interests did not have anything to do with the problems of secured lenders. Instead, it grew out of the so-called "paperwork crunch" which came to a head in the late 1960's in the securities industry... financial intermediaries and other bailees will presumably have records showing which notices were received when. Nothing in the revised article 8 affects this.
@@ -204,7 +204,7 @@ At least third request to submit ID to "activate crypto transfers" which started
 which of course can't even link to main bank account....
 
 
-## Series EE Bonds
+### Series EE Bonds
 
 Adjustment to account letter dated January 6, 2025, stated the savings bond "was redeemed for an incorrect amount."
 
@@ -212,9 +212,9 @@ The actual amount was 40% less, with $100 being redeemed as $59.76.
 
 The account was debited into overdraft due to human error discrepancy. The message was signed "SSS" from the bank's "Centralized Operations."
 
-## Starting Confliction Story
+### Starting cvna Story
 
-**Remove any ticker reference** per: https://discordapp.com/channels/1102309240145707049/1122936843537764352/1329454851150581852
+//Remove any ticker reference
 
 ### Key Facts
 
@@ -237,6 +237,56 @@ This resulted in the disposition of Lumens bought at or about the price level on
 It also offers a stellar place to insert arguments against central intermediation of the transfer process.[^cb] Hopefully, these and additional emotional arguments around the last FOIA in OCC (24-01211-E) and more recently 25-00185-FOIA will push the Commission toward the 501(c)(3)'s side. :)
 
 Recently, indaequate  administrative procedures of an unreliable central broker cost me and my partner $100k in the last couple of months.
+
+
+
+## OPen Source Community
+
+I started rafting this letter in true form after an oipening community discussion[^GH-discussion] in our growing public GitHub collaboation system. Therafeter,m we discussed the contents and implications of these policy amendmnts at depth.[^TS-TAR-ep] ore broadly, we'vve been dioscussing the necvesary strucutral changes and adoption plans for the better part of a year in our  ollective Discord server, as is additionally common in modern blockchain development groups.[^Discord-GME]
+
+[^GH-discussion]: _See_ "Transfer Agent Regulations in the Era of Blockchain" conversation, _available at_ https://github.com/WhyDRS/SEC-Comments/discussions/14.
+
+[^TS-TAR-ep]: _See_ one of many weekly markter advancement discussions and intervites, _available at_ https://lnns.co/_bCOQT1AKdi.
+
+[^Discord-GME]: _See_ "Mionopoly Bailout Discussion" as first refernce in extended pirece on growing systemic risks, _available at_ https://wooten.link/GME. _See also_ invitation to join the poublic server, open to any internet usert, _available at_ https://wooten.link/join. Staff will need to configure an account and enter the group before viewing the context of the first link and other searcharble discussions over this concept release.
+
+*Indeed, we'r eproduced a mountain of pioneering research, actively clarifying meaningufl ownerhsp concepts[^heat-lamp] alobgside the Commission's helpful stewardace. Remarkably, as someone new to the COmmitity these last couple years (conotically), all this action took place with no central coordinator, no compensatedion mechinasm, and no legal offices. We live in a very different time than the days past when our dcurrent systems originated.[^diff-time] Give n the burefonong enciomentmen........ the Commission  belive XYZ more maschiline... now is the time a new and stested system ?
+
+[^heat-lamp]: _See, e.g.,_ comments referencing a "due diligence library" with hundreds of original research prieces discoing meaningful operational nuances not known to the markets; _available at_ https://www.sec.gov/comments/s7-14-22/s71422-279105.htm, https://www.sec.gov/comments/s7-08-22/s70822-272484.htm, https://www.sec.gov/comments/s7-18-21/s71821-20111377-264966.pdf, _inter alia_. _See also relevantly_ one particular piece documenting the operational-efficeiny custodinashoip practices of certain agent share purchase plans, expanding operative trust past the bounds specified in concept release § VII.E.2, _available at_ https://wooten.link/heat. Namel, we have confirmed throuh discussions, conversations ,and by definative website "Q&A sectopm" updates certain operations by a leading transfer agent which allow shares held in a directly-regisreted investpors' name to be swept into agent nominee custodianship without due notice or concent should such investor enroll in an issuer plan, be it directly sehlfed on an S-3 or not volunatarily perpetuated by issuers themselves. While the release does mention this option as a possabilty for known brokered holdings, I find it materially worrison given the declared holding of plan-custodian nominee shares in a DTCC/Cede account at a market bropker for the sake of accessing trading liquidityh,.
+
+[^diff-time]: _See_ Congressional request 86 Stat. 1586 to reprint 156,000 physcial paper copies of the report from _supra_ note {{UCC-BASIC}}, , _available at_ https://www.govinfo.gov/content/pkg/STATUTE-86/pdf/STATUTE-86-Pg1586.pdf, in terms of pages assumoing double-sided printing. The technologies we have toay vastly outmatch the infrastrue in place during the origins (and in many cases the continuing present poerations) of today's SRO monopolies/. AND IT'S MY INTERPREATION AFTER CONVversaiton with a C-suite executive therewith (or those closely related) that the change and efficiny imporvmenet promises inherit in transparent and accountbale distirbuted eldger technolgoies will come olnly ffomr a grossroot communtiy-lead effort such as ours.
+
+Our shared developments these past few years have showed me just khow efficintly online forumes and collaborative working tools orgnaize otherwise dispersre invdiduaual investor and financial-system advocates. WEit hthis basis , we can direclt, specifically, and immutably process thoughts and inspiratiaons into production codepabases processing material amounts of value, such as Bitcoin.[^this-comment] Given DTCC has recently porposed a TAD-like collective securities owenrship framework, we resectfully submit that any such system shoulc be required to be open sourcesd under a copyleft free softwaree license so as to tfirst theis collective collatorbation.[^DTC-DA-study]
+
+[^this-comment]: _See, e.g.,_ permissionless work audits and online iteration of underlying inter0gagent account system between myself and community members bound by no formal work arrangements, _available at_ https://github.com/JFWooten4/DUNA-docs/issues/3. The three links in the first comment reference specific instances of others independently revuiewubg ubfratryetyre code preparing fofrr release. Without hte ability fort a public review of an open aaccounting standard, I res[pectfully] submit to the Commission that we risk material prortietaryt sopftrware errors ~~such as those previously idenitief~~should oour most crucial financial intermediaries in the CCP Regiume continue ignoring the dominant open-source seucirty hardening benefits availed freey to public code respoitories. <!-- href here next time with quote from Jerry -->
+
+[^DTC-DA-study]: _See_ DTC sutcy here:https://www.dtcc.com/-/media/WhitePapers/Transforming-Collateral-Management-With-Digital-Assets-JSCC.pdf discussed: https://github.com/WhyDRS/Taking-Stock/blob/main/episodes/2024/Oct/30%3A%20DTCC%20Digital%20Assets%20Study.md at https://lnns.co/O8NUZfc1KGe
+I really don't see a need to formally achonledge this becuase it is a complete joke
+That said I think the competiton arguemtns are apparent, and we can clearly infer the propoerarity
+much of it comes from the orgnaiation setup of everything in terms of teh stud partook with no notice to the COmmission or industy; that's a larger item which comes more into the who open source ops thing (so tck le in sepearte locaiton)
+
+
+we can do this - ytes we can ——— _Make THem believe_
+
+
+seldct clkips:
+
+collelctive SS mod interview of Conn in case of no cshares in Cede:
+https://www.youtube.com/clip/UgkxV1YeRljQHPcN4NO5aBdj1HPS7apnbNrC
+
+indpednent PB research of "kill switch" as intro'd 
+https://www.youtube.com/clip/Ugkxd0_I3EmB6m2oRNnJ2kTku32HTsIleI34
+on a FUCKING SLOW DOWN PIT STOP at https://www.dtcc.com/-/media/Files/Downloads/issues/Unscheduled_Close.pdf
+that refs to https://wooten.link/DTC-closure-v1
+altN: https://wooten.link/DTC-closure-v2
+
+original document tnmetnioned in June 4 was amended on Dec 30 2024
+removed the ability of issers to access "Security Position Reports" or the "Issuer Agent Portal" (grom change at 6)
+
+fine and the Bob clipo
+https://www.youtube.com/clip/UgkxX1DN63sYrhFeAXBDM76mAyRXQBl-TGME
+
+and then simply to _cpmapore_ the prafialy of these infsittutions with the cdecnetralized scalaed global ledger techongology existisant on blockchain _ 
 
 
 
@@ -406,6 +456,55 @@ Received at least three calls from LR and a compliance email mandating a call by
 
 ## Share Donation Section
 
+possibly, good idea to start with the natural monpoly conversation an implications of a shared strandar like nscc-ish
+
+
+
+> If ultimate economic power is to be placed in the hands of commercial corporation, as is now the trend, democracy will live only in words, not in reality, for corporate governance of such organization is the antithesis of democracy—or of equity and justice, for that matter.
+> 
+> —Dee Hock
+
+I agree with the late Visa network founder's theiss that the infrasturcre unedletingh outr markets should not lay in the corruptabel hadns of a select few indsutry intermediareieos.  We;ve seen the further and further onsolidation of DTCC adn its naturasl squashing of transfer-agent innvoation. Now is the time for a new ,m parllel rail avalibale to investors seeking directy cusotdu of their investment seucieritre.s It is my understanding that the present administration made a promise to keep us fortified from Wall Street's "predatory short selling" resulting in the FTD problem.[^RFK-camp]
+
+[^RFK-camp]: _See_ pending cabinet apopitntees' sentiments in prior compainging efforts, _available at_ https://x.com/RobertKennedyJr/status/1792970117204287992. Give nthe martial supportt Kennedy lendign towards the Administration's ultimate vicotry in final public-decision moments, might we keep the promise to our grat Nation's individual investors? A committment to establish "a free and fair market" with "aggressive Wall Street reforms" based around "greater transparency" could be easimly eimplkmeneted with a blockchain securitiers trading and settlement systme.
+
+As the Commission knows, I am the aslo fouinder of a registerd transfer agent operating using the public open-source blockcvhain system communicated in previous letters. As sahred, I have built this systen iover tge ciyurse of many years of technical analysis, regulatory study, amd Pythonic implkmeentation.[^repos] As the primary contirbutor towards these refforts, I still both retail all shares in teh agent and control the licencing nature of my work.
+
+[^repos]: _See_ primary impementation of trading infrastructreo on GithUb, _available at_ https://github.com/blocktransfer/py-TAD3-horizon.
+
+I have chose n to re;lease the vast majoirty of Syndicate GithUb code under expressly permissive copleft free software licenses.[^FOSS] This allows andy agnets to deploy our secutrities managemnt infrastructreo on top of the blockahin for fast, accourate, and auoptamic recorkdeepinhg; including on-chain restrictirve-legend removeals under 17 C.F.R. § 230.144. By the nature of this open-soruce techonlgoy, the parent agent corpoation cannot restrict or otherwise manage oversight into agents deplying the permissionless-ethosd sytme.
+
+[^FOSS]: : _See_ communityy iscussion as to licencisng implications, , _available at_ https://wooten.link/GNU. As for limited implementation progression, _See also_ pending open source work without ending r=policies, _available at_ https://github.com/blocktransfer/investor-app and https://github.com/blocktransfer/issuerlink. It is my express intention to maintain a deference and employment of Affero amonst all continuing syticate work, or its equivalent for ducmentation efforts .
+
+### Natural Monpoly Rsisk
+
+
+
+---
+
+Accordingly, it's my intention to donate my shares in the company to WhyDRS, presuming that's sometihgni the communti ywould liek to happen. I am still weeding through the legalities and tax iomp[lications ] of this transfer given the treeatment of interest under 26 U.S.C. § 1361(b)(1)(B), _inter alia._ NOtwithstanding, I intend to gifue out the details here in a manner which grants tyhe ASsociation binding and enforcabel control over the company.
+
+Firstly, I would appreacite a reply from staff within 90 days as to  the owenrshipo of a blockchain transfer agent by the DUNA, as such a nnonprofit arranglemtyn mimics existing regualtory-oversight schemes availed of Federal recogniztion. Implications from the Commission's response to this gift could materially assist communtiy members with an analysis of whetehr or not ot accept the shares. Naemly, this combination of euals into a superstructure for public intfrastrucutre quite directly raises the particpatory and reputational bar for our ongoing  social efforts towards efficient markets.
+
+Secondaly,y lol idkl maybe we can introduce putting this out to commetn again
+
+
+
+
+
+
+WEhat we need shopuld DTC fail is nothign short of a completel ynew (inter)national market syustem.[^global]  I find the proestepcts of such a maket controlled by one private corporatiuon bleak. Given past experience shows the cebtralizing tendandcy of good clearing infrastructe,[^DTCC-path]
+
+[^global]: In such an interconnected aera with profound technological abudnance,m I see only invetably the emmergance of a bglboal stock market. I earnestly hope that our great Nation will continrue leading the forefront of the worl'd capitla market by supporting this work. _See also_ work in a number of  foriegn nations implementaiong an inter-agency Direct Registration System, _available at_ https://ijlr.iledu.in/wp-content/uploads/2023/06/V3I205.pdf#page=3. (insider trading link ehre...) ~~THe vast bulk of this work emplyos propeirtaty, centralized, and corruptable cenatl brookeepers~~
+
+[^DTCC-path]: : _See_ documentation from Dr. Dan Awrey, J.D. and Joshua Macey, J.D. detialing the monopolization of market plumbing, _available at_ https://www.yalelawjournal.org/article/open-access.
+
+---
+
+
+here we can itnroduce the shared inter-gagent standard avaliable as an open sotck transfer prtocol. 
+
+
 In this interview calling for a tightenign of brokerage credit: (https://www.marketscreener.com/quote/stock/INTERACTIVE-BROKERS-GROUP-50014/news/Thomas-Peterffy-Talks-Trump-M-A-Cryptocurrencies-48573820/ - don't href)
 
 just ref as with Bloomberg Radio "last month"
@@ -421,6 +520,30 @@ just ref as with Bloomberg Radio "last month"
 Similar power track as running validators, which we should introduce on a single-entity basis with triad implications.
 
 ^Should include a footnote related to setting a reorganization record so other nations can follow jurisprudence on TAs implementing TAD3 and investors uncovering government roles.
+
+
+
+
+
+Lumen alignment footnote igfven the network affect and its according impact on price in a market for ayer-1 utility tokens
+can href https://www.youtube.com/watch?v=OrpHfZcywJw&list=PLD_o9ntBnmGam9BuoTr_4cjPOksi1Dl1A&t=92 in support of former claim
+
+
+2290.24 XLM on 9 Jul 2024 for dev docs bounty 1/2, cite as https://github.com/stellar/stellar-docs/commit/a2961ace1761153b5e1b0296bfa59da2648cc0f5
+- https://stellar.expert/explorer/public/tx/1df8235ead4630006b56d9fb2e9c896cb13b74aacedb6d9fa766129474dcf0ea
+
+1 XLM on 8 Jul 2024 for account validation as per dev docs bug
+- https://stellar.expert/explorer/public/tx/9f537d66c78e33fec085ca860924af25888ded4df5a51f3968ef7b888c6063d0
+
+FCA00C: on 10 Mar 2023, cite as https://github.com/JFWooten4/FCA00C-asteroids
+5xlm and 20 USDC
+- https://stellar.expert/explorer/public/tx/e6594e76f58f2b4c030160b5584287446c5e0037f7432d73f7c46559feedf437
+
+5XLM and 5USDC
+- https://stellar.expert/explorer/public/tx/cca6b58d054918a686b3c89da263ee9f2d056dab3a835cda71a3b299ade3bfac
+
+
+also, I gues it would be irresponsible to not say that "I have unsucesffuly applied for funding from the SDF or its related projects engaging in the dirspebsement of the network's native layert-1 utiltiy token at least three times, and I personally do not particually plan to apply for such financial support again "~~given our pgoress with no outside corporate funding~~
 
 ### Outreach ot Other Aghents
 


### PR DESCRIPTION
I'm debating whether or not to give any room or space for mentioning the opposing argument and preemption that "the banking industry will push back on this." Clearly, that's the case, but I don't see why we should bother preempting that, given they've already started spewing their own lies in Tennessee. Ultimately, all this will likely come out in a recorded Congressional testimony or panel talks. So any discussions around those nuances fall squarely outside the scope of the Commission.

They didn't acknowledge note 4 of [EDGAR](https://wooten.link/edgar), so I've got to think they don't want to deal with the systemic idiosyncratic risk head-on before we have a proven TAD system capable of replacing the CCP regime. Thus, a quieter ruling preemption that enforces incorporation doctrine and subsidiary operations ought to handle the required investor protections (incl. funds).

Solves JFWooten4/DUNA-docs#5 with ignorance and indifference to the state policymaker perspective handled by Don and necessarily ready for staff interpretation on a broad protective basis.
